### PR TITLE
fix: Use #!/usr/bin/env bash rather than #!/bin/bash

### DIFF
--- a/scripts/copy_fhe_keys.sh
+++ b/scripts/copy_fhe_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This bash script creates global fhe keys
 # and copy them to the right folder in volumes directory.

--- a/scripts/get_kms_core_version.sh
+++ b/scripts/get_kms_core_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if a file name is provided as an argument
 if [ $# -eq 0 ]; then

--- a/scripts/get_repository_info.sh
+++ b/scripts/get_repository_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 REPO_NAME=$1
 REPO_PATH=$2

--- a/scripts/prepare_test.sh
+++ b/scripts/prepare_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 make run-full
 # Deploy ACL, Gateway ..., please wait until the end before testing!!!

--- a/scripts/prepare_volumes_from_kms_core.sh
+++ b/scripts/prepare_volumes_from_kms_core.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This bash script creates global fhe keys
 # and copy them to the right folder in volumes directory.

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CHAINID="ethermint_9000-1"
 MONIKER="localtestnet"


### PR DESCRIPTION
As an act of selfless kindness to non FHS-compliant OSes (like NixOS)

This should be strictly more portable than the current shebang