### PR TITLE
chore: use ssh to clone git repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(WORKDIR)/:
 
 clone-fhevm-solidity: $(WORKDIR)/
 	$(info Cloning fhevm-solidity version $(FHEVM_SOLIDITY_VERSION))
-	cd $(WORKDIR) && git clone https://github.com/zama-ai/fhevm.git
+	cd $(WORKDIR) && git clone git@github.com:zama-ai/fhevm.git
 	cd $(FHEVM_SOLIDITY_PATH) && git checkout $(FHEVM_SOLIDITY_VERSION)
 
 check-fhevm-solidity: $(WORKDIR)/
@@ -86,9 +86,9 @@ else
 	$(MAKE) clone-fhevm-solidity
 endif
 
-clone-coprocessor: $(WORKDIR)/ 
+clone-coprocessor: $(WORKDIR)/
 	$(info Cloning coprocessor version $(COPROCESSOR_VERSION))
-	cd $(WORKDIR) && git clone https://github.com/zama-ai/fhevm-backend.git
+	cd $(WORKDIR) && git clone git@github.com:zama-ai/fhevm-backend.git
 	cd $(COPROCESSOR_PATH) && git checkout $(COPROCESSOR_VERSION)
 
 run-coprocessor: $(WORKDIR)/ check-coprocessor generate-fhe-keys-registry-dev-image
@@ -97,7 +97,7 @@ run-coprocessor: $(WORKDIR)/ check-coprocessor generate-fhe-keys-registry-dev-im
 	cd $(COPROCESSOR_PATH)/fhevm-engine/coprocessor && cargo install sqlx-cli
 	cd $(COPROCESSOR_PATH)/fhevm-engine/coprocessor && make init_db
 
-stop-coprocessor: $(WORKDIR)/ 
+stop-coprocessor: $(WORKDIR)/
 	cd $(COPROCESSOR_PATH)/fhevm-engine/coprocessor && make cleanup
 
 


### PR DESCRIPTION
Use SSH to clone the github repos.
This removes the requirement to create access tokens for private repos.